### PR TITLE
bump upper bound on wreq

### DIFF
--- a/ekg-bosun.cabal
+++ b/ekg-bosun.cabal
@@ -28,7 +28,7 @@ library
     time >=1.4 && <1.5,
     unordered-containers >=0.2 && <0.3,
     vector >=0.10 && <0.11,
-    wreq >= 0.2 && < 0.3,
+    wreq >= 0.2 && < 0.4,
     old-locale
   hs-source-dirs: src
   default-language: Haskell2010


### PR DESCRIPTION
Seems to build and test successfully with wreq-0.3.0.

I'd like to bump the upper bound for NixOS as this the only derivation to depend on wreq-0.2.*.
